### PR TITLE
Fix convert entity selector name

### DIFF
--- a/pkg/reader/template.go
+++ b/pkg/reader/template.go
@@ -2,6 +2,7 @@ package reader
 
 import (
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/bannzai/repository_from_sqlboiler/pkg/strutil"
@@ -17,7 +18,15 @@ var functions = template.FuncMap{
 	"golangVariableCase":   golangVariableCase,
 	"golangStructNameCase": strutil.SpecializeUpperCamelCase,
 	"plural":               strutil.Plural,
-	"entitySelectorName":   strutil.Plural,
+	"entitySelectorName":   entitySelectorName,
+}
+
+func entitySelectorName(str string) string {
+	str = strings.ToLower(str)
+	str = strutil.SnakeCase(str)
+	str = strutil.Plural(str)
+	str = strutil.UpperCamelCase(str)
+	return str
 }
 
 func golangArgumentCase(str string) string {

--- a/pkg/reader/template.go
+++ b/pkg/reader/template.go
@@ -21,11 +21,35 @@ var functions = template.FuncMap{
 	"entitySelectorName":   entitySelectorName,
 }
 
+// reference: https://github.com/volatiletech/sqlboiler/blob/4dea9a5f77e3ec6090ad455df3d408e47e077700/strmangle/strmangle.go#L25
+var lowercaseWords = map[string]string{
+	"ACL":   "Acl",
+	"API":   "Api",
+	"ASCII": "Ascii",
+	"CPU":   "Cpu",
+	"EOF":   "Eof",
+	"GUID":  "Guid",
+	"ID":    "Id",
+	"IP":    "Ip",
+	"JSON":  "Json",
+	"RAM":   "Ram",
+	"SLA":   "Sla",
+	"UDP":   "Udp",
+	"UI":    "Ui",
+	"UID":   "Uid",
+	"UUID":  "Uuid",
+	"URI":   "Uri",
+	"URL":   "Url",
+	"UTF8":  "Utf8",
+}
+
 func entitySelectorName(str string) string {
-	str = strings.ToLower(str)
-	str = strutil.SnakeCase(str)
+	for keyword, converted := range lowercaseWords {
+		if strings.Contains(str, keyword) {
+			str = strings.ReplaceAll(str, keyword, converted)
+		}
+	}
 	str = strutil.Plural(str)
-	str = strutil.UpperCamelCase(str)
 	return str
 }
 

--- a/pkg/reader/template.go
+++ b/pkg/reader/template.go
@@ -16,7 +16,7 @@ var functions = template.FuncMap{
 	"sqlParameterCase":     strutil.SnakeCase,
 	"golangArgumentCase":   golangArgumentCase,
 	"golangVariableCase":   golangVariableCase,
-	"golangStructNameCase": strutil.SpecializeUpperCamelCase,
+	"golangStructNameCase": golangStructNameCase,
 	"plural":               strutil.Plural,
 	"entitySelectorName":   entitySelectorName,
 }
@@ -41,6 +41,10 @@ var lowercaseWords = map[string]string{
 	"URI":   "Uri",
 	"URL":   "Url",
 	"UTF8":  "Utf8",
+}
+
+func golangStructNameCase(entityName string) string {
+	return entityName
 }
 
 func entitySelectorName(str string) string {

--- a/pkg/reader/template_test.go
+++ b/pkg/reader/template_test.go
@@ -1,0 +1,90 @@
+package reader
+
+import (
+	"reflect"
+	"testing"
+	"text/template"
+)
+
+func Test_entitySelectorName(t *testing.T) {
+	type args struct {
+		str string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := entitySelectorName(tt.args.str); got != tt.want {
+				t.Errorf("entitySelectorName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_golangArgumentCase(t *testing.T) {
+	type args struct {
+		str string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := golangArgumentCase(tt.args.str); got != tt.want {
+				t.Errorf("golangArgumentCase() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_golangVariableCase(t *testing.T) {
+	type args struct {
+		str string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := golangVariableCase(tt.args.str); got != tt.want {
+				t.Errorf("golangVariableCase() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTemplate_Read(t *testing.T) {
+	type fields struct {
+		FilePath string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   *template.Template
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t := Template{
+				FilePath: tt.fields.FilePath,
+			}
+			if got := t.Read(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Template.Read() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/reader/template_test.go
+++ b/pkg/reader/template_test.go
@@ -1,9 +1,7 @@
 package reader
 
 import (
-	"reflect"
 	"testing"
-	"text/template"
 )
 
 func Test_entitySelectorName(t *testing.T) {
@@ -15,7 +13,34 @@ func Test_entitySelectorName(t *testing.T) {
 		args args
 		want string
 	}{
-		// TODO: Add test cases.
+		{
+			name: "User to Users",
+			args: args{
+				str: "User",
+			},
+			want: "Users",
+		},
+		{
+			name: "CoordinateItem to CoordinateItems",
+			args: args{
+				str: "CoordinateItem",
+			},
+			want: "CoordinateItems",
+		},
+		{
+			name: "XyzJSON to XyzJsons",
+			args: args{
+				str: "XyzJSON",
+			},
+			want: "XyzJsons",
+		},
+		{
+			name: "XJSON to XJsons",
+			args: args{
+				str: "XJSON",
+			},
+			want: "XJsons",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -61,29 +86,6 @@ func Test_golangVariableCase(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := golangVariableCase(tt.args.str); got != tt.want {
 				t.Errorf("golangVariableCase() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestTemplate_Read(t *testing.T) {
-	type fields struct {
-		FilePath string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   *template.Template
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t := Template{
-				FilePath: tt.fields.FilePath,
-			}
-			if got := t.Read(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Template.Read() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/strutil/name.go
+++ b/pkg/strutil/name.go
@@ -73,28 +73,3 @@ func SpecializeUpperCamelCase(str string) string {
 	}
 	return UpperCamelCase(str)
 }
-
-func Plural(str string) string {
-	if len(str) < 2 {
-		return str
-	}
-	if str[len(str)-1:] == "s" ||
-		str[len(str)-2:] == "sh" ||
-		str[len(str)-2:] == "ch" ||
-		str[len(str)-1:] == "o" ||
-		str[len(str)-1:] == "x" {
-		return str + "es"
-	}
-	if str[len(str)-1:] == "f" {
-		return str[0:len(str)-1] + "ves"
-	}
-	if str[len(str)-2:] == "fe" {
-		return str[0:len(str)-2] + "ves"
-	}
-	isExists, _ := regexp.MatchString(".+[^aiueo]y$", str)
-	if isExists {
-		return str[0:len(str)-1] + "ies"
-	}
-
-	return str + "s"
-}

--- a/pkg/strutil/name_test.go
+++ b/pkg/strutil/name_test.go
@@ -240,36 +240,3 @@ func TestEscapedReservedWord(t *testing.T) {
 		})
 	}
 }
-
-func TestPlural(t *testing.T) {
-	type args struct {
-		str string
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "user to users",
-			args: args{
-				str: "user",
-			},
-			want: "users",
-		},
-		{
-			name: "community to communities",
-			args: args{
-				str: "community",
-			},
-			want: "communities",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := Plural(tt.args.str); got != tt.want {
-				t.Errorf("Plural() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}

--- a/pkg/strutil/plural.go
+++ b/pkg/strutil/plural.go
@@ -15,6 +15,9 @@ func Plural(str string) string {
 		if len(key) > len(str) {
 			continue
 		}
+		if len(key) <= 0 {
+			continue
+		}
 		if key == str[len(str)-len(key):] {
 			replaced := str[:len(str)-len(key)] + converted
 			return replaced

--- a/pkg/strutil/plural.go
+++ b/pkg/strutil/plural.go
@@ -1,0 +1,28 @@
+package strutil
+
+import "regexp"
+
+func Plural(str string) string {
+	if len(str) < 2 {
+		return str
+	}
+	if str[len(str)-1:] == "s" ||
+		str[len(str)-2:] == "sh" ||
+		str[len(str)-2:] == "ch" ||
+		str[len(str)-1:] == "o" ||
+		str[len(str)-1:] == "x" {
+		return str + "es"
+	}
+	if str[len(str)-1:] == "f" {
+		return str[0:len(str)-1] + "ves"
+	}
+	if str[len(str)-2:] == "fe" {
+		return str[0:len(str)-2] + "ves"
+	}
+	isExists, _ := regexp.MatchString(".+[^aiueo]y$", str)
+	if isExists {
+		return str[0:len(str)-1] + "ies"
+	}
+
+	return str + "s"
+}

--- a/pkg/strutil/plural.go
+++ b/pkg/strutil/plural.go
@@ -1,8 +1,27 @@
 package strutil
 
-import "regexp"
+import (
+	"fmt"
+	"regexp"
+)
+
+var ruleSets = map[string]string{
+	"": "",
+}
 
 func Plural(str string) string {
+	// specialize Rule
+	for key, converted := range ruleSets {
+		if len(key) > len(str) {
+			continue
+		}
+		if key == str[len(str)-len(key):] {
+			replaced := str[:len(str)-len(key)] + converted
+			return replaced
+		}
+	}
+
+	// normalize convert plural
 	if len(str) < 2 {
 		return str
 	}
@@ -24,5 +43,6 @@ func Plural(str string) string {
 		return str[0:len(str)-1] + "ies"
 	}
 
+	fmt.Printf("str = %v\n", str)
 	return str + "s"
 }

--- a/pkg/strutil/plural_test.go
+++ b/pkg/strutil/plural_test.go
@@ -1,0 +1,23 @@
+package strutil
+
+import "testing"
+
+func TestPlural(t *testing.T) {
+	type args struct {
+		str string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Plural(tt.args.str); got != tt.want {
+				t.Errorf("Plural() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/strutil/plural_test.go
+++ b/pkg/strutil/plural_test.go
@@ -25,6 +25,13 @@ func TestPlural(t *testing.T) {
 			},
 			want: "communities",
 		},
+		{
+			name: "JSON to Jsons",
+			args: args{
+				str: "JSON",
+			},
+			want: "Jsons",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/strutil/plural_test.go
+++ b/pkg/strutil/plural_test.go
@@ -11,7 +11,20 @@ func TestPlural(t *testing.T) {
 		args args
 		want string
 	}{
-		// TODO: Add test cases.
+		{
+			name: "user to users",
+			args: args{
+				str: "user",
+			},
+			want: "users",
+		},
+		{
+			name: "community to communities",
+			args: args{
+				str: "community",
+			},
+			want: "communities",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/strutil/plural_test.go
+++ b/pkg/strutil/plural_test.go
@@ -26,7 +26,7 @@ func TestPlural(t *testing.T) {
 			want: "communities",
 		},
 		{
-			name: "JSON to Jsons",
+			name: "JSON to JSONs",
 			args: args{
 				str: "JSON",
 			},

--- a/pkg/strutil/plural_test.go
+++ b/pkg/strutil/plural_test.go
@@ -30,7 +30,7 @@ func TestPlural(t *testing.T) {
 			args: args{
 				str: "JSON",
 			},
-			want: "Jsons",
+			want: "JSONs",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## What
- Fix generate fetch database model selector name.

## Why
sqlboiler not integrate to convert rule between generating database model and fetch database model method name.

e.g) x_json table got database model structure named XJSON, But if in the case of fetch database model method name, it got XJsons in sqlboiler.

reference:
https://github.com/volatiletech/sqlboiler/blob/4dea9a5f77e3ec6090ad455df3d408e47e077700/boilingcore/aliases.go#L57
https://github.com/volatiletech/sqlboiler/blob/4dea9a5f77e3ec6090ad455df3d408e47e077700//strmangle/strmangle.go#L25