### PR TITLE
Fix debug code

### DIFF
--- a/pkg/strutil/plural.go
+++ b/pkg/strutil/plural.go
@@ -1,7 +1,6 @@
 package strutil
 
 import (
-	"fmt"
 	"regexp"
 	"strconv"
 )
@@ -57,6 +56,5 @@ func PluralSuffix(str string) string {
 		return str[0:len(str)-1] + "ies"
 	}
 
-	fmt.Printf("str = %v\n", str)
 	return str + "s"
 }

--- a/pkg/writer/file.go
+++ b/pkg/writer/file.go
@@ -18,5 +18,5 @@ func (f File) Write(content string) {
 	if err := ioutil.WriteFile(f.FilePath, []byte(content), 0644); err != nil {
 		panic(err)
 	}
-	fmt.Fprintf(os.Stdout, "Generated %s. \n", f.FilePath)
+	fmt.Fprintf(os.Stdout, "Generated %s \n", f.FilePath)
 }


### PR DESCRIPTION
## What
- Remove unnecessary debug code for fmt.Printf
- Remove `.` from log.